### PR TITLE
lint 기준 추가 설정 (import order 정렬)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,6 +15,27 @@
 		"browser": true
 	},
 	"rules": {
-		"@typescript-eslint/no-explicit-any": "warn"
+		"@typescript-eslint/no-explicit-any": "warn",
+		"import/order": [
+			"error",
+			{
+				"groups": [
+					"builtin",
+					"external",
+					"internal",
+					"parent",
+					"sibling",
+					"index",
+					"object",
+					"type"
+				],
+				"alphabetize": {
+					"order": "asc",
+					"caseInsensitive": true
+				},
+				"newlines-between": "never"
+			}
+
+		]
 	}
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,8 +1,8 @@
-import type { Metadata } from 'next';
-import React from 'react';
+import { Metadata } from 'next';
 import { Inter } from 'next/font/google';
-import './globals.css';
+import React from 'react';
 import Header from '../components/Header';
+import './globals.css';
 
 const inter = Inter({ subsets: ['latin'] });
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,5 @@
-import { NavItems } from '@/util/enum';
 import Link from 'next/link';
-import React from 'react';
+import { NavItems } from '@/util/enum';
 
 const Header = () => {
 	return (


### PR DESCRIPTION
- docs 예시에 따라 group화
```
"import/order": [
  "error",
  {
    "groups": [
      "index",
      "sibling",
      "parent",
      "internal",
      "external",
      "builtin",
      "object",
      "type"
    ]
  }
]
```

- 알파벳 오름차순으로 정렬
```
"alphabetize": {
	"order": "asc",
	"caseInsensitive": true
},