### PR TITLE
React.Forwardref 적용하는 방식으로 변경

### DIFF
--- a/src/app/admin/components/Select.tsx
+++ b/src/app/admin/components/Select.tsx
@@ -1,22 +1,24 @@
 import { FormElements } from '../page';
-import React from 'react';
+import React, { forwardRef } from 'react';
 import { UseFormRegister } from 'react-hook-form';
 
 type SelectProps = {
-	register: UseFormRegister<FormElements>;
 	name: 'category1' | 'category2';
 };
 
-const Select = ({ register, name }: SelectProps) => {
-	return (
-		<li className="flex w-full flex-col">
-			<label className="text-gray-mid-light">{name}</label>
-			<select
-				{...register(name, { required: true })}
-				className="h-10 rounded-sm border border-gray-mid-light focus:outline-gray"
-			/>
-		</li>
-	);
-};
+const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
+	(props, ref) => {
+		return (
+			<li className="flex w-full flex-col">
+				<label className="text-gray-mid-light">{props.name}</label>
+				<select
+					{...props}
+					ref={ref}
+					className="h-10 rounded-sm border border-gray-mid-light focus:outline-gray"
+				/>
+			</li>
+		);
+	},
+);
 
 export default Select;

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -30,10 +30,10 @@ const AdminPage = () => {
 			{isOpen && (
 				<>
 					<Input {...register('title')} />
-					{/* <ul className="flex w-full flex-row gap-x-12 focus:outline-gray">
-						<Select register={register} name="category1" />
-						<Select register={register} name="category2" />
-					</ul> */}
+					<ul className="flex w-full flex-row gap-x-12 focus:outline-gray">
+						<Select {...register('category1')} />
+						<Select {...register('category2')} />
+					</ul>
 					<MDEditor value={value} onChange={setValue} />
 				</>
 			)}


### PR DESCRIPTION
- 기존에 forwardRef를 적용했을 때 제목 부분을 닫는 버튼을 클릭하면 제목 input이 빈 값이 되는 문제가 생겼어서 적용을 보류했었음.
- 원인은 forwardRef 내에서 input에 prop을 적용하지 않았기 때문이었고, 오늘 깨달아서 적용